### PR TITLE
Fix searchCity() overwriting input with partial display_name

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -239,7 +239,6 @@
           const lon = parseFloat(data[0].lon);
           map.flyTo([lat, lon], 13);
           setSearchCenter({ lat, lng: lon });
-          document.getElementById('citySearch').value = data[0].display_name.split(',')[0];
         } else { alert("Città non trovata"); }
       } catch(e) { alert("Errore ricerca città"); }
     }


### PR DESCRIPTION
Nominatim returns display_name as "22, Corso Spezia, Torino, ..." for addresses, so split(',')[0] produced just the house number. Removed the line entirely — the input keeps whatever the user typed.

https://claude.ai/code/session_017xnthbq4ZMeCxftnhg11ah